### PR TITLE
Prevent integer 'identifiers' value from being matched as a string in SQL query

### DIFF
--- a/library/mysql_query.py
+++ b/library/mysql_query.py
@@ -134,7 +134,7 @@ def change_required(state, cursor, table, identifiers, desired_values):
     query = "select %(columns)s from %(table)s where %(values)s" % dict(
         table=table,
         columns=", ".join(desired_values.keys()) if state == 'present' else '*',
-        values=" AND ".join(map(lambda x: "%s='%s'" % x, identifiers.items())),
+        values=" AND ".join(map(lambda x: ("%s=%s" if type(x[1]) == int else "%s='%s'") % x, identifiers.items())),
     )
 
     try:


### PR DESCRIPTION
This patch makes sure that an integer passed as an `identifiers` value does not get surrounded in quotes and accidentally matched as a string in the SQL query that determines if a row already exists.

Without this patch, the example below
```
mysql_query:
  name: db_name
  table: table_name
  identifiers:
    id: 1234
    name: 'my_name'
  values:
    id: 1234
    name: 'my_name'
```
would be turned into the following SQL query:
```
select `id`, `name` from `table_name` where `id`='1234' AND `name`='my name'
```
which wouldn't find any rows if our `id` column is of type `int()`.

With the patch, the example above generates the following SQL query instead, and still surrounds string values with quotes:
```
select `id`, `name` from `table_name` where `id`=1234 AND `name`='my name'
```

Note: I have also verified that this patch works when using Jinja 2.10's new native type support which can be enabled in Ansible 2.7 by specifying `jinja2_native = True` in ansible.cfg's `[defaults]` section.